### PR TITLE
[hotfix] fix hardcoded default value for label voxel size/resolution

### DIFF
--- a/miracl/reg/miracl_reg_clar-allen.sh
+++ b/miracl/reg/miracl_reg_clar-allen.sh
@@ -863,7 +863,7 @@ function warpallenlbls() {
   # c3d ${tiflbls} -resample ${ox}x${oy}x${oz}mm -o ${restif}
 
   # get tiflbls dim
-  tiflblsdim=$(PrintHeader reg_final/annotation_hemi_combined_10um_clar_vox.tif 2)
+  tiflblsdim=$(PrintHeader reg_final/annotation_hemi_combined_"${vox}"um_clar_vox.tif 2)
   IFS='x' read -ra dimensions <<<"$tiflblsdim"
   tiflblsx="${dimensions[0]}"
   tiflblsy="${dimensions[1]}"


### PR DESCRIPTION
The voxel size/resolution for the tiff labels was hardcoded to 10um for tiflblsdim which gets the image dims. This would break tiff creation in reg_final for different voxel sizes e.g. 50um.